### PR TITLE
Request to Merge

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
@@ -96,7 +96,7 @@ final class HandlerScheduler extends Scheduler {
         private final Handler handler;
         private final Runnable delegate;
 
-        private volatile boolean disposed;
+        private volatile boolean disposed; // Tracked solely for isDisposed().
 
         ScheduledRunnable(Handler handler, Runnable delegate) {
             this.handler = handler;
@@ -114,8 +114,8 @@ final class HandlerScheduler extends Scheduler {
 
         @Override
         public void dispose() {
-            disposed = true;
             handler.removeCallbacks(this);
+            disposed = true;
         }
 
         @Override


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a race condition in the `dispose()` method of the `ScheduledRunnable` class by ensuring that handler callbacks are removed before setting the `disposed` flag to `true`.
- Added a comment to clarify that the `disposed` variable is tracked solely for accurate `isDisposed()` reporting.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HandlerScheduler.java</strong><dd><code>Fix race condition in `dispose()` method of `ScheduledRunnable`</code></dd></summary>
<hr>

rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java

<li>Moved the setting of <code>disposed</code> to <code>true</code> after removing callbacks.<br> <li> Added a comment to clarify the purpose of the <code>disposed</code> variable.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/RxAndroid/pull/1/files#diff-5c410381ada99646eeab4bd63e0a3a795333669f05d06ab58f4bf8b900545da8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Made internal improvements to scheduling operations for clearer execution and enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->